### PR TITLE
Make query parameters work with graph.del()

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -295,7 +295,7 @@ exports.post = function (url, postData, callback) {
 
 exports.del = function (url, callback) {
   if (!url.match(/[?|&]method=delete/i)) {
-    url += ~url.indexOf('?') ? '?' : '&';
+    url += ~url.indexOf('?') ? '&' : '?';
     url += 'method=delete';
   }
 


### PR DESCRIPTION
I'm passing ?access_token=... into graph.del() and it wouldn't work without this fix.
