### PR TITLE
Pass postData on from del() to post()

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -290,16 +290,17 @@ exports.post = function (url, postData, callback) {
  * a post call, along with a method=delete param
  *
  * @param {string} url
+ * @param {object} postData
  * @param {function} callback
  */
 
-exports.del = function (url, callback) {
+exports.del = function (url, postData, callback) {
   if (!url.match(/[?|&]method=delete/i)) {
     url += ~url.indexOf('?') ? '&' : '?';
     url += 'method=delete';
   }
 
-  this.post(url, callback);
+  this.post(url, postData, callback);
 };
 
 


### PR DESCRIPTION
The way we're using this library is without ever logging in the client but instead passing the access token along with every request. This makes that work for DELETE requests.
