### PR TITLE
Fix for creating secret proof for non-static access tokens.

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -102,9 +102,11 @@ Graph.prototype.prepareUrl = function(url) {
 
 Graph.prototype.cleanUrl = function(url) {
   url = url.trim();
+
+  // prep access token in url for appsecret proofing
   var regex = /access_token=([^&]*)/;
   var results = regex.exec(url);
-  var token = results ? results[1] : accessToken;
+  var sessionAccessToken = results ? results[1] : accessToken;
 
   // add leading slash
   if (url.charAt(0) !== '/' && url.substr(0,4) !== 'http') url = '/' + url;
@@ -116,9 +118,9 @@ Graph.prototype.cleanUrl = function(url) {
   }
 
   // add appsecret_proof to the url
-  if (token && appSecret && url.indexOf('appsecret_proof') === -1) {
+  if (sessionAccessToken && appSecret && url.indexOf('appsecret_proof') === -1) {
     var hmac = crypto.createHmac('sha256', appSecret);
-    hmac.update(token);
+    hmac.update(sessionAccessToken);
 
     url += ~url.indexOf('?') ? '&' : '?';
     url += "appsecret_proof=" + hmac.digest('hex');


### PR DESCRIPTION
Wrong secret_proof was being generated when an access token is specified in the URL.
