### PR TITLE
Allow access_token to be replaced for single batch

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -356,10 +356,10 @@ exports.batch = function (reqs, additionalData, callback) {
     additionalData = {};
   }
 
-  return new Graph('POST', '', extend({}, additionalData, {
+  return new Graph('POST', '', extend({}, {
     access_token: accessToken,
     batch: JSON.stringify(reqs)
-  }), callback);
+  }, additionalData), callback);
 };
 
 


### PR DESCRIPTION
The way it was, calling 
 `graph.batch(actios, {access_token: 'whateveruwant'}, cb)` would result in a empty access token, every time, except if global accessToken was set.
