### PR TITLE
Pass del body along to post call

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -310,16 +310,22 @@ exports.post = function (url, postData, callback) {
  * a post call, along with a method=delete param
  *
  * @param {string} url
+ * @param {object} postData (optional)
  * @param {function} callback
  */
 
-exports.del = function (url, callback) {
+exports.del = function (url, postData, callback) {
   if (!url.match(/[?|&]method=delete/i)) {
     url += ~url.indexOf('?') ? '&' : '?';
     url += 'method=delete';
   }
 
-  this.post(url, callback);
+  if (typeof postData === 'function') {
+    callback = postData;
+    postData = url.indexOf('access_token') !== -1 ? {} : {access_token: accessToken};
+  }
+
+  this.post(url, postData, callback);
 };
 
 


### PR DESCRIPTION
The Graph API requires delete calls to include a body in certain cases. This little patch makes that straightforward.
