### PR TITLE
added setVersion for setting graph api version

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -33,8 +33,8 @@ var accessToken          = null
   , appSecret            = null
   , graphUrl             = 'https://graph.facebook.com'
   , graphVersion         = '1.0' // default to the oldest version
-  , oauthDialogUrl       = "http://www.facebook.com/dialog/oauth?"
-  , oauthDialogUrlMobile = "http://m.facebook.com/dialog/oauth?"
+  , oauthDialogUrl       = "http://www.facebook.com/v1.0/dialog/oauth?" // oldest version for auth
+  , oauthDialogUrlMobile = "http://m.facebook.com/v1.0/dialog/oauth?"   // oldest version for auth
   , requestOptions       = {};
 
 /**
@@ -504,7 +504,13 @@ exports.getAccessToken = function () {
  * @param {string} version
  */
 exports.setVersion = function (version) {
+  // set version
   graphVersion = version;
+
+  // update auth urls
+  oauthDialogUrl       = "http://www.facebook.com/v"+version+"/dialog/oauth?" // oldest version for auth
+  oauthDialogUrlMobile = "http://m.facebook.com/v"+version+"/dialog/oauth?"   // oldest version for auth
+
   return this;
 };
 


### PR DESCRIPTION
Took me long enough! Apologies for the delay.

@xpepermint commented [here](https://github.com/criso/fbgraph/issues/54#issuecomment-57127331) regarding also adding the version to the OAuth dialog URLs, which would probably work, but it's not officially recommended or documented in [Facebook's docs](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/v2.1), so I didn't add it.

Didn't try getting the tests to work as you mentioned they were a little flaky.
