### PR TITLE
create debug option to print requests

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -35,7 +35,8 @@ var accessToken          = null
   , graphVersion         = '1.0' // default to the oldest version
   , oauthDialogUrl       = "http://www.facebook.com/v1.0/dialog/oauth?" // oldest version for auth
   , oauthDialogUrlMobile = "http://m.facebook.com/v1.0/dialog/oauth?"   // oldest version for auth
-  , requestOptions       = {};
+  , requestOptions       = {}
+  , debug                = false;
 
 /**
  * Library version
@@ -178,6 +179,9 @@ Graph.prototype.end = function (body) {
 Graph.prototype.get = function () {
   var self = this;
 
+  if (debug) {
+    console.log(this.options);
+  }
   request.get(this.options, function(err, res, body) {
     if (err) {
       self.callback({
@@ -211,6 +215,9 @@ Graph.prototype.post = function() {
 
   this.options.body  = postData;
 
+  if (debug) {
+    console.log(this.options);
+  }
   request(this.options, function (err, res, body) {
     if (err) {
       self.callback({
@@ -548,4 +555,12 @@ exports.setGraphUrl = function (url) {
 
 exports.getGraphUrl = function() {
   return graphUrl;
+};
+
+/**
+ * sets debug mode flag
+ */
+exports.setDebug = function(val) {
+  debug = val;
+  return this;
 };


### PR DESCRIPTION
Adds a debug option. When enabled, the content of every request made to Facebook is printed.