### PR TITLE
with access to api request

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ Possible options can be found on the [request github page](https://github.com/mi
 `followRedirect` cannot be overriden and has a default value of `false`
 `encoding` will have `utf-8` as default if nothing is set
 
+### Request Object
+The request object is exposed as a property on graph object. So that all the [request](https://github.com/mikeal/request) api can be accessed.
+
+```js
+var graphObject = graph
+  .get("zuck", function(err, res) {
+    console.log(res); // { id: '4', name: 'Mark Zuckerberg'... }
+  });
+
+// abort the request.
+graphObject.request.abort();
+
+```
+
 ### Pagination
 Pagination in Facebook is done either with a `cursor` or a `next` url to call.
 To simplify the fbgraph API, it's possible to use a fully constructed URL in order to get

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -72,7 +72,7 @@ function Graph(method, url, postData, callback) {
   this.options.uri            = url;
   this.options.followRedirect = false;
 
-  this[method.toLowerCase()]();
+  this.request = this[method.toLowerCase()]();
 
   return this;
 }
@@ -178,7 +178,7 @@ Graph.prototype.end = function (body) {
 Graph.prototype.get = function () {
   var self = this;
 
-  request.get(this.options, function(err, res, body) {
+  return request.get(this.options, function(err, res, body) {
     if (err) {
       self.callback({
           message: 'Error processing https request'
@@ -211,7 +211,7 @@ Graph.prototype.post = function() {
 
   this.options.body  = postData;
 
-  request(this.options, function (err, res, body) {
+  return request(this.options, function (err, res, body) {
     if (err) {
       self.callback({
           message: 'Error processing https request'
@@ -326,7 +326,7 @@ exports.del = function (url, postData, callback) {
     postData = url.indexOf('access_token') !== -1 ? {} : {access_token: accessToken};
   }
 
-  this.post(url, postData, callback);
+  return this.post(url, postData, callback);
 };
 
 
@@ -345,7 +345,7 @@ exports.search = function (options, callback) {
 
 /**
  * Perform a batch query on the graph api
- * 
+ *
  * @param  {Array}    reqs     An array containing queries
  * @param  {[Object]} additionalData Additional data to send, e.g. attachments or the `include_headers` parameter.
  * @param  {Function} callback
@@ -426,7 +426,7 @@ exports.getOauthUrl = function (params, opts) {
 exports.authorize = function (params, callback) {
   var self = this;
 
-  this.get("/oauth/access_token", params, function(err, res) {
+  return this.get("/oauth/access_token", params, function(err, res) {
     if (!err) self.setAccessToken(res.access_token);
 
     callback(err, res);
@@ -449,7 +449,7 @@ exports.extendAccessToken = function (params, callback) {
     params.grant_type        = 'fb_exchange_token';
     params.fb_exchange_token = params.access_token ? params.access_token : this.getAccessToken();
 
-    this.get("/oauth/access_token", params, function(err, res) {
+    return this.get("/oauth/access_token", params, function(err, res) {
       if (!err && !params.access_token) {
         self.setAccessToken(res.access_token);
       }
@@ -498,8 +498,8 @@ exports.getAccessToken = function () {
 };
 
 /**
- * Set's the Graph API version. 
- * Note that you don't need to specify the 'v', just 
+ * Set's the Graph API version.
+ * Note that you don't need to specify the 'v', just
  * add '2.1', '1.1' etc
  * @param {string} version
  */


### PR DESCRIPTION
expose the call to request methods so that they can be aborted. e.g graph.request.abort().