### PR TITLE
update request module to 2.72.x for security reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "index",
   "dependencies": {
-    "request": "2.40.x",
+    "request": "2.72.x",
     "qs": "1.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated request dependancy to 2.72.0, which uses hawk 3.1.3. Previous versions of hawk are vulnerable to a regex DOS (fbgraph currently uses v1.1.1).

Please see this CVE for more info:
https://nodesecurity.io/advisories/77
