### PR TITLE
Made login urls protocol agnostic

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -33,8 +33,8 @@ var accessToken          = null
   , appSecret            = null
   , graphUrl             = 'https://graph.facebook.com'
   , graphVersion         = '2.4' // default to the oldest version
-  , oauthDialogUrl       = "http://www.facebook.com/v2.0/dialog/oauth?" // oldest version for auth
-  , oauthDialogUrlMobile = "http://m.facebook.com/v2.0/dialog/oauth?"   // oldest version for auth
+  , oauthDialogUrl       = "//www.facebook.com/v2.0/dialog/oauth?" // oldest version for auth
+  , oauthDialogUrlMobile = "//m.facebook.com/v2.0/dialog/oauth?"   // oldest version for auth
   , requestOptions       = {};
 
 /**
@@ -508,8 +508,8 @@ exports.setVersion = function (version) {
   graphVersion = version;
 
   // update auth urls
-  oauthDialogUrl       = "http://www.facebook.com/v"+version+"/dialog/oauth?"; // oldest version for auth
-  oauthDialogUrlMobile = "http://m.facebook.com/v"+version+"/dialog/oauth?";   // oldest version for auth
+  oauthDialogUrl       = "//www.facebook.com/v"+version+"/dialog/oauth?"; // oldest version for auth
+  oauthDialogUrlMobile = "//m.facebook.com/v"+version+"/dialog/oauth?";   // oldest version for auth
 
   return this;
 };


### PR DESCRIPTION
I faced an issue where auth wasn't being redirect from server and the login dialog was being blocked, resulting in a white canvas page on Safari and Chrome.  Site is running https but redirecting to http was causing the request to block.
