### PR TITLE
Switch from Request to phin

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -2,7 +2,7 @@
  * Module Dependencies
  */
 
-var request      = require('request')
+var phin         = require('phin')
   , qs           = require('qs')
   , url          = require('url')
   , crypto       = require('crypto')
@@ -65,12 +65,10 @@ function Graph(method, url, postData, callback) {
   this.postData = postData;
 
   this.options          = extend({}, requestOptions);
-  this.options.encoding = this.options.encoding || 'utf-8';
 
   // these particular set of options should be immutable
   this.options.method         = method;
-  this.options.uri            = url;
-  this.options.followRedirect = false;
+  this.options.url            = url;
 
   this.request = this[method.toLowerCase()]();
 
@@ -178,7 +176,7 @@ Graph.prototype.end = function (body) {
 Graph.prototype.get = function () {
   var self = this;
 
-  return request.get(this.options, function(err, res, body) {
+  return phin(this.options, function(err, res) {
     if (err) {
       self.callback({
           message: 'Error processing https request'
@@ -187,6 +185,8 @@ Graph.prototype.get = function () {
 
       return;
     }
+
+    var body = res.body.toString();
 
     if (~res.headers['content-type'].indexOf('image')) {
       body = {
@@ -209,9 +209,9 @@ Graph.prototype.post = function() {
   var self     = this
     , postData = qs.stringify(this.postData);
 
-  this.options.body  = postData;
+  this.options.data  = postData;
 
-  return request(this.options, function (err, res, body) {
+  return phin(this.options, function (err, res) {
     if (err) {
       self.callback({
           message: 'Error processing https request'
@@ -221,7 +221,7 @@ Graph.prototype.post = function() {
       return;
     }
 
-    self.end(body);
+    self.end(res.body);
   });
 
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "fbgraph",
+  "version": "1.4.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "phin": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-2.2.4.tgz",
+      "integrity": "sha512-9KAAVStmAgqj9K+nRQYVqt5ehcZ2LkTKqnXNXnInGrB6StG6MRKwX8wvYaapGyGMOoshlJLdEDQ8YPnIVSAKaw=="
+    },
+    "qs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+      "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "main": "index",
   "dependencies": {
-    "qs": "^1.2.2",
-    "request": "^2.79.0"
+    "phin": "^2.2.4",
+    "qs": "^1.2.2"
   },
   "devDependencies": {
     "vows": "^0.7.0"


### PR DESCRIPTION
[phin](https://github.com/Ethanent/phin) is a lightweight, fast HTTP request package. phin has 0 dependencies while request has a considerably [large dependency tree](http://npm.anvaka.com/#/view/2d/request).

Switching to phin seems improves install time and request performance for the package!