### PR TITLE
set https oAuth dialog URLs when changing API version

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -508,8 +508,8 @@ exports.setVersion = function (version) {
   graphVersion = version;
 
   // update auth urls
-  oauthDialogUrl       = "http://www.facebook.com/v"+version+"/dialog/oauth?"; // oldest version for auth
-  oauthDialogUrlMobile = "http://m.facebook.com/v"+version+"/dialog/oauth?";   // oldest version for auth
+  oauthDialogUrl       = "https://www.facebook.com/v"+version+"/dialog/oauth?"; // oldest version for auth
+  oauthDialogUrlMobile = "https://m.facebook.com/v"+version+"/dialog/oauth?";   // oldest version for auth
 
   return this;
 };


### PR DESCRIPTION
This fixes the oauth dialog, as it's now trying to load unsafe scripts.